### PR TITLE
Remove duplicate script entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "git://github.com/fraserxu/react-dropdown.git"
   },
-  "scripts": {
-    "build": "node_modules/.bin/babel src/index.js > index.js"
-  },
   "keywords": [
     "react",
     "react-component",


### PR DESCRIPTION
This removes a duplicate entry for `script` which caused me a little bit of confusion.