### PR TITLE
Judge ismounted to avoid error warning

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -23,6 +23,7 @@ var Dropdown = (function (_React$Component) {
       selected: props.value || { label: "Select...", value: "" },
       isOpen: false
     };
+    this.mounted = true;
   }
 
   _inherits(Dropdown, _React$Component);
@@ -42,6 +43,7 @@ var Dropdown = (function (_React$Component) {
     },
     componentWillUnmount: {
       value: function componentWillUnmount() {
+        this.mounted = false;
         document.removeEventListener("click", this.handleDocumentClick.bind(this), false);
       }
     },
@@ -124,8 +126,10 @@ var Dropdown = (function (_React$Component) {
     },
     handleDocumentClick: {
       value: function handleDocumentClick(event) {
-        if (!React.findDOMNode(this).contains(event.target)) {
-          this.setState({ isOpen: false });
+        if (this.mounted) {
+          if (!React.findDOMNode(this).contains(event.target)) {
+            this.setState({ isOpen: false });
+          }
         }
       }
     },

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ class Dropdown extends React.Component {
       selected: props.value || { label: 'Select...', value: '' },
       isOpen: false
     }
+    this.mounted = true;
   }
 
   componentWillReceiveProps(newProps) {
@@ -26,6 +27,7 @@ class Dropdown extends React.Component {
   }
 
   componentWillUnmount() {
+    this.mounted = false;
     document.removeEventListener("click", this.handleDocumentClick.bind(this), false);
   }
 
@@ -85,8 +87,10 @@ class Dropdown extends React.Component {
   }
 
   handleDocumentClick(event) {
-    if (!React.findDOMNode(this).contains(event.target)) {
-      this.setState({isOpen:false});
+    if(this.mounted) {
+      if (!React.findDOMNode(this).contains(event.target)) {
+        this.setState({isOpen:false});
+      }
     }
   }
 


### PR DESCRIPTION
The problem is comes from the global click event bind in ComponentWillMount.

Global click event is likely to be trigger unexpected(bubble or asynchronous), so if the component(Dropdown) hasn't been mounted, the React.findDOMNode(component) will give an error of `Error: Invariant Violation: Component (with keys: props,context,state,refs,_reactInternalInstance) contains `render` method but is not mounted in the DOM`

So we need to judge mounted condition, but ES6 won't support isMounted(), so I add `this.mounted = true` in constructor and `this.mounted = false` in componentWillUnmount. Then judge mounted situation in function `handleDocumentClick`
