### PR TITLE
custom className for Dropdown-control and Dropdown-menu via props

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -135,6 +135,10 @@ var Dropdown = (function (_React$Component) {
     },
     render: {
       value: function render() {
+        var _props = this.props;
+        var controlClassName = _props.controlClassName;
+        var menuClassName = _props.menuClassName;
+
         var value = React.createElement(
           "div",
           { className: "placeholder" },
@@ -142,7 +146,7 @@ var Dropdown = (function (_React$Component) {
         );
         var menu = this.state.isOpen ? React.createElement(
           "div",
-          { className: "Dropdown-menu" },
+          { className: menuClassName },
           this.buildMenu()
         ) : null;
 
@@ -156,7 +160,7 @@ var Dropdown = (function (_React$Component) {
           { className: dropdownClass },
           React.createElement(
             "div",
-            { className: "Dropdown-control", onMouseDown: this.handleMouseDown.bind(this), onTouchEnd: this.handleMouseDown.bind(this) },
+            { className: controlClassName, onMouseDown: this.handleMouseDown.bind(this), onTouchEnd: this.handleMouseDown.bind(this) },
             value,
             React.createElement("span", { className: "Dropdown-arrow" })
           ),
@@ -169,5 +173,6 @@ var Dropdown = (function (_React$Component) {
   return Dropdown;
 })(React.Component);
 
+Dropdown.defaultProps = { controlClassName: "Dropdown-control", menuClassName: "Dropdown-menu" };
 module.exports = Dropdown;
 

--- a/index.js
+++ b/index.js
@@ -95,8 +95,9 @@ class Dropdown extends React.Component {
   }
 
   render() {
+    const { controlClassName, menuClassName } = this.props;
     let value = (<div className='placeholder'>{this.state.selected.label}</div>);
-    let menu = this.state.isOpen ? <div className='Dropdown-menu'>{this.buildMenu()}</div> : null;
+    let menu = this.state.isOpen ? <div className={menuClassName}>{this.buildMenu()}</div> : null;
 
     let dropdownClass = classNames({
       'Dropdown': true,
@@ -105,7 +106,7 @@ class Dropdown extends React.Component {
 
     return (
       <div className={dropdownClass}>
-        <div className='Dropdown-control' onMouseDown={this.handleMouseDown.bind(this)} onTouchEnd={this.handleMouseDown.bind(this)}>
+        <div className={controlClassName} onMouseDown={this.handleMouseDown.bind(this)} onTouchEnd={this.handleMouseDown.bind(this)}>
           {value}
           <span className='Dropdown-arrow' />
         </div>
@@ -115,5 +116,5 @@ class Dropdown extends React.Component {
   }
 
 }
-
+Dropdown.defaultProps = { controlClassName: 'Dropdown-control', menuClassName: 'Dropdown-menu'};
 export default Dropdown;


### PR DESCRIPTION
Allows user to pass in custom class name replacing Dropdown-control and Dropdown-menu via props. 

Closes #2, #13 