### PR TITLE
Allow customizing classes with a baseClassName prop

### DIFF
--- a/example/style.css
+++ b/example/style.css
@@ -23,7 +23,7 @@ pre code {
   padding: 8px 0;
 }
 
-.Dropdown {
+.Dropdown-root {
   position: relative;
 }
 
@@ -79,7 +79,7 @@ pre code {
   -webkit-overflow-scrolling: touch;
 }
 
-.Dropdown-menu .group > .title{
+.Dropdown-menu .Dropdown-group > .Dropdown-title {
   padding: 8px 10px;
   color: rgba(51, 51, 51, 1.2);
   font-weight: bold;

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ class Dropdown extends React.Component {
 
   renderOption (option) {
     let optionClass = classNames({
-      'Dropdown-option': true,
+      [`${this.props.baseClassName}-option`]: true,
       'is-selected': option == this.state.selected
     });
 
@@ -77,13 +77,14 @@ class Dropdown extends React.Component {
   }
 
   buildMenu() {
-    let ops = this.props.options.map((option) => {
+    let { options, baseClassName } = this.props;
+    let ops = options.map((option) => {
       if (option.type == 'group') {
-        let groupTitle = (<div className='title'>{option.name}</div>);
+        let groupTitle = (<div className={`${baseClassName}-title`}>{option.name}</div>);
         let _options = option.items.map((item) => this.renderOption(item));
 
         return (
-          <div className='group' key={option.name}>
+          <div className={`${baseClassName}-group`} key={option.name}>
             {groupTitle}
             {_options}
           </div>
@@ -93,7 +94,7 @@ class Dropdown extends React.Component {
       }
     })
 
-    return ops.length ? ops : <div className='Dropdown-noresults'>No options found</div>;
+    return ops.length ? ops : <div className={`${baseClassName}-noresults`}>No options found</div>;
   }
 
   handleDocumentClick(event) {
@@ -105,20 +106,20 @@ class Dropdown extends React.Component {
   }
 
   render() {
-    const { controlClassName, menuClassName } = this.props;
-    let value = (<div className='placeholder'>{this.state.selected.label}</div>);
-    let menu = this.state.isOpen ? <div className={menuClassName}>{this.buildMenu()}</div> : null;
+    const { baseClassName } = this.props;
+    let value = (<div className={`${baseClassName}-placeholder`}>{this.state.selected.label}</div>);
+    let menu = this.state.isOpen ? <div className={`${baseClassName}-menu`}>{this.buildMenu()}</div> : null;
 
     let dropdownClass = classNames({
-      'Dropdown': true,
+      [`${baseClassName}-root`]: true,
       'is-open': this.state.isOpen
     });
 
     return (
       <div className={dropdownClass}>
-        <div className={controlClassName} onMouseDown={this.handleMouseDown.bind(this)} onTouchEnd={this.handleMouseDown.bind(this)}>
+        <div className={`${baseClassName}-control`} onMouseDown={this.handleMouseDown.bind(this)} onTouchEnd={this.handleMouseDown.bind(this)}>
           {value}
-          <span className='Dropdown-arrow' />
+          <span className={`${baseClassName}-arrow`} />
         </div>
         {menu}
       </div>
@@ -126,5 +127,5 @@ class Dropdown extends React.Component {
   }
 
 }
-Dropdown.defaultProps = { controlClassName: 'Dropdown-control', menuClassName: 'Dropdown-menu'};
+Dropdown.defaultProps = { baseClassName: "Dropdown" };
 export default Dropdown;

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-.Dropdown {
+.Dropdown-root {
   position: relative;
 }
 
@@ -54,7 +54,7 @@
   -webkit-overflow-scrolling: touch;
 }
 
-.Dropdown-menu .group > .title{
+.Dropdown-menu .Dropdown-group > .Dropdown-title{
   padding: 8px 10px;
   color: rgba(51, 51, 51, 1);
   font-weight: bold;


### PR DESCRIPTION
Allow adding classes to the root div with the `className` props, so that
```jsx
<Dropdown className="foobar" />
```
renders
```html
<div class="Dropdown foobar">
```