### PR TITLE
Fix double React error in example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "babelify": "^5.0.4",
     "watchify": "^2.6.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
   }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,10 @@
     "url": "https://github.com/fraserxu/react-dropdown/issues"
   },
   "homepage": "https://github.com/fraserxu/react-dropdown",
-  "peerDependencies": {
+  "dependencies": {
+    "classnames": "^2.1.3",
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
-  },
-  "dependencies": {
-    "classnames": "^2.1.3"
   },
   "devDependencies": {
     "babel": "^4.7.16",


### PR DESCRIPTION
Fix the ```Warning: React can't find the root component node for data-reactid value `.0.3`. If you're seeing this message, it probably means that you've loaded two copies of React on the page. At this time, only a single copy of React can be loaded at a time.warning```-error on the demo page.