### PR TITLE
Add package.json#style

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.2",
   "description": "React dropdown component",
   "main": "dist/index.js",
+  "style": "style.css",
   "repository": {
     "type": "git",
     "url": "git://github.com/fraserxu/react-dropdown.git"


### PR DESCRIPTION
Adds a style property in the package.json file to support tools that look for the main css file of the module.

I personally needed it for [cssnext](https://github.com/MoOx/postcss-cssnext) which uses [postcss-import](https://github.com/postcss/postcss-import) to @import npm modules. Seems to be [relatively common elsewhere](http://stackoverflow.com/questions/32037150/style-field-in-package-json/32042285#32042285) too, notably used by [bootstrap](https://github.com/twbs/bootstrap/blob/master/package.json#L20).