### PR TITLE
Added Fixes for Closing Dropdown for Mobile Devices

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -62,12 +62,14 @@ var Dropdown = function (_Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       document.addEventListener('click', this.handleDocumentClick, false);
+      document.addEventListener('touchend', this.handleDocumentClick, false);
     }
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
       this.mounted = false;
       document.removeEventListener('click', this.handleDocumentClick, false);
+      document.removeEventListener('touchend', this.handleDocumentClick, false);
     }
   }, {
     key: 'handleMouseDown',

--- a/index.js
+++ b/index.js
@@ -27,11 +27,13 @@ class Dropdown extends Component {
 
   componentDidMount () {
     document.addEventListener('click', this.handleDocumentClick, false)
+    document.addEventListener('touchend', this.handleDocumentClick, false)
   }
 
   componentWillUnmount () {
     this.mounted = false
     document.removeEventListener('click', this.handleDocumentClick, false)
+    document.removeEventListener('touchend', this.handleDocumentClick, false)
   }
 
   handleMouseDown (event) {


### PR DESCRIPTION
Feature =>
When we use Multiple Dropdown on same page, opening second dropdown
should hide the first dropdown if it was opened previously.

This feature works well in desktop but in mobile devices where we have
touch based event, it was not working properly, i.e. In a mobile device
if we open the 2nd dropdown while the 1st dropdown was still open, it
would just open 2nd dropdown without closing the 1st one.

Fix =>
Adding Event Listeners for “touchend” event for mobile devices.
This will dismiss the currently opened dropdown if we click anywhere on
the document  except the current dropdown itself.
Clicking on second dropdown while the first one is still open will
close the first dropdown and opens the second dropdown.
This feature will work in all types of devices, i.e. Mobile, Desktop,
etc.