### PR TITLE
Move React deps into peer and dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   },
   "homepage": "https://github.com/fraserxu/react-dropdown",
   "dependencies": {
-    "classnames": "^2.2.3",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "classnames": "^2.2.3"
+  },
+  "peerDependencies": {
+    "react": ">=0.14.7 <0.15.0",
+    "react-dom": ">=0.14.7 <0.15.0"
   },
   "browserify": {
     "transform": [
@@ -48,6 +50,8 @@
     "browserify-hmr": "^0.3.1",
     "ecstatic": "^1.4.0",
     "gh-pages": "^0.11.0",
+    "react": ">=0.14.7 <0.15.0",
+    "react-dom": ">=0.14.7 <0.15.0",
     "standard": "^6.0.7",
     "watchify": "^3.7.0"
   },


### PR DESCRIPTION
Move React deps into `peerDependencies` and `devDependencies`. Tested installing my branch in my project with this configuration and the conflicting React error is gone.

https://github.com/fraserxu/react-dropdown/issues/40