### PR TITLE
implement basic keyboard accessibility

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -83,6 +83,30 @@ var Dropdown = function (_Component) {
       });
     }
   }, {
+    key: 'handleMenuKeyDown',
+    value: function handleMenuKeyDown(event) {
+      // 32 === SPC char code
+      if (event.which === 32) {
+        this.setState({
+          isOpen: !this.state.isOpen
+        });
+
+        event.preventDefault();
+        return false;
+      }
+    }
+  }, {
+    key: 'handleOptionKeyDown',
+    value: function handleOptionKeyDown(value, label, event) {
+      // 32 === SPC char code
+      if (event.which === 32) {
+        this.setValue(value, label);
+
+        event.preventDefault();
+        return false;
+      }
+    }
+  }, {
     key: 'setValue',
     value: function setValue(value, label) {
       var newState = {
@@ -116,7 +140,9 @@ var Dropdown = function (_Component) {
         'div',
         {
           key: value,
+          tabIndex: '0',
           className: optionClass,
+          onKeyDown: this.handleOptionKeyDown.bind(this, value, label),
           onMouseDown: this.setValue.bind(this, value, label),
           onClick: this.setValue.bind(this, value, label) },
         label
@@ -194,7 +220,7 @@ var Dropdown = function (_Component) {
         { className: dropdownClass },
         _react2.default.createElement(
           'div',
-          { className: baseClassName + '-control', onMouseDown: this.handleMouseDown.bind(this), onTouchEnd: this.handleMouseDown.bind(this) },
+          { className: baseClassName + '-control', onMouseDown: this.handleMouseDown.bind(this), onTouchEnd: this.handleMouseDown.bind(this), onKeyDown: this.handleMenuKeyDown.bind(this), tabIndex: '0' },
           value,
           _react2.default.createElement('span', { className: baseClassName + '-arrow' })
         ),

--- a/index.js
+++ b/index.js
@@ -46,6 +46,28 @@ class Dropdown extends Component {
     })
   }
 
+  handleMenuKeyDown (event) {
+    // 32 === SPC char code
+    if (event.which === 32) {
+      this.setState({
+        isOpen: !this.state.isOpen
+      })
+
+      event.preventDefault()
+      return false
+    }
+  }
+
+  handleOptionKeyDown (value, label, event) {
+    // 32 === SPC char code
+    if (event.which === 32) {
+      this.setValue(value, label)
+
+      event.preventDefault()
+      return false
+    }
+  }
+
   setValue (value, label) {
     let newState = {
       selected: {
@@ -76,7 +98,9 @@ class Dropdown extends Component {
     return (
       <div
         key={value}
+        tabIndex='0'
         className={optionClass}
+        onKeyDown={this.handleOptionKeyDown.bind(this, value, label)}
         onMouseDown={this.setValue.bind(this, value, label)}
         onClick={this.setValue.bind(this, value, label)}>
         {label}
@@ -126,7 +150,7 @@ class Dropdown extends Component {
 
     return (
       <div className={dropdownClass}>
-        <div className={`${baseClassName}-control`} onMouseDown={this.handleMouseDown.bind(this)} onTouchEnd={this.handleMouseDown.bind(this)}>
+        <div className={`${baseClassName}-control`} onMouseDown={this.handleMouseDown.bind(this)} onTouchEnd={this.handleMouseDown.bind(this)} onKeyDown={this.handleMenuKeyDown.bind(this)} tabIndex='0'>
           {value}
           <span className={`${baseClassName}-arrow`} />
         </div>


### PR DESCRIPTION
Implements the following features:
- make menu and menu options tabbable
- allow menu toggle and option select by pressing space

Great for keyboard-only users and general usability.

I'm using a fork with these changes on a raspberrypi media browser project (that's intended to be controlled with a keyboard/remote): https://github.com/felixmc/rpi-media-browser
