### PR TITLE
Use full option

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -84,22 +84,19 @@ var Dropdown = function (_Component) {
     }
   }, {
     key: 'setValue',
-    value: function setValue(value, label) {
+    value: function setValue(option) {
       var newState = {
-        selected: {
-          value: value,
-          label: label
-        },
+        selected: option,
         isOpen: false
       };
-      this.fireChangeEvent(newState);
+      this.fireChangeEvent(option);
       this.setState(newState);
     }
   }, {
     key: 'fireChangeEvent',
-    value: function fireChangeEvent(newState) {
-      if (newState.selected !== this.state.selected && this.props.onChange) {
-        this.props.onChange(newState.selected);
+    value: function fireChangeEvent(option) {
+      if (option !== this.state.selected && this.props.onChange) {
+        this.props.onChange(option);
       }
     }
   }, {
@@ -109,16 +106,16 @@ var Dropdown = function (_Component) {
 
       var optionClass = (0, _classnames2.default)((_classNames = {}, _defineProperty(_classNames, this.props.baseClassName + '-option', true), _defineProperty(_classNames, 'is-selected', option === this.state.selected), _classNames));
 
-      var value = option.value || option.label || option;
-      var label = option.label || option.value || option;
+      var value = typeof option.value === 'undefined' ? option : option.value;
+      var label = typeof option.label === 'undefined' ? option : option.label;
 
       return _react2.default.createElement(
         'div',
         {
           key: value,
           className: optionClass,
-          onMouseDown: this.setValue.bind(this, value, label),
-          onClick: this.setValue.bind(this, value, label) },
+          onMouseDown: this.setValue.bind(this, option),
+          onClick: this.setValue.bind(this, option) },
         label
       );
     }

--- a/example/flatArrayExample.js
+++ b/example/flatArrayExample.js
@@ -15,7 +15,7 @@ class FlatArrayExample extends Component {
   }
 
   _onSelect (option) {
-    console.log('You selected ', option.label)
+    console.log('You selected ', option)
     this.setState({selected: option})
   }
 

--- a/example/objectArrayExample.js
+++ b/example/objectArrayExample.js
@@ -11,7 +11,7 @@ class ObjectArrayExample extends Component {
   }
 
   _onSelect (option) {
-    console.log('You selected ', option.label)
+    console.log('You selected ', option)
     this.setState({selected: option})
   }
 

--- a/example/objectArrayExample.js
+++ b/example/objectArrayExample.js
@@ -4,8 +4,25 @@ import Dropdown from '../index.js'
 class ObjectArrayExample extends Component {
   constructor (props) {
     super(props)
+    const options = [
+      { value: 'one', label: 'One' },
+      { value: 'two', label: 'Two' },
+      {
+        type: 'group', name: 'group1', items: [
+          { value: 'three', label: 'Three' },
+          { value: 'four', label: 'Four' }
+        ]
+      },
+      {
+        type: 'group', name: 'group2', items: [
+          { value: 'five', label: 'Five' },
+          { value: 'six', label: 'Six' }
+        ]
+      }
+      ]
     this.state = {
-      selected: { value: 'two', label: 'Two'}
+      options,
+      selected: options[1]
     }
     this._onSelect = this._onSelect.bind(this)
   }
@@ -16,30 +33,13 @@ class ObjectArrayExample extends Component {
   }
 
   render () {
-    const options = [
-      { value: 'one', label: 'One' },
-      { value: 'two', label: 'Two' },
-      {
-       type: 'group', name: 'group1', items: [
-         { value: 'three', label: 'Three' },
-         { value: 'four', label: 'Four' }
-       ]
-      },
-      {
-       type: 'group', name: 'group2', items: [
-         { value: 'five', label: 'Five' },
-         { value: 'six', label: 'Six' }
-       ]
-      }
-    ]
-
     const defaultOption = this.state.selected
     const placeHolderValue = typeof this.state.selected === 'string' ? this.state.selected : this.state.selected.label
 
     return (
       <section>
         <h4>Object Array Example </h4>
-        <Dropdown options={options} onChange={this._onSelect} value={defaultOption} placeholder="Select an option" />
+        <Dropdown options={this.state.options} onChange={this._onSelect} value={defaultOption} placeholder="Select an option" />
         <div className='result'>
           You selected
           <strong> {placeHolderValue} </strong>

--- a/index.js
+++ b/index.js
@@ -46,21 +46,18 @@ class Dropdown extends Component {
     })
   }
 
-  setValue (value, label) {
-    let newState = {
-      selected: {
-        value,
-        label
-      },
+  setValue (option) {
+    const newState = {
+      selected: option,
       isOpen: false
     }
-    this.fireChangeEvent(newState)
+    this.fireChangeEvent(option)
     this.setState(newState)
   }
 
-  fireChangeEvent (newState) {
-    if (newState.selected !== this.state.selected && this.props.onChange) {
-      this.props.onChange(newState.selected)
+  fireChangeEvent (option) {
+    if (option !== this.state.selected && this.props.onChange) {
+      this.props.onChange(option)
     }
   }
 
@@ -70,15 +67,15 @@ class Dropdown extends Component {
       'is-selected': option === this.state.selected
     })
 
-    let value = option.value || option.label || option
-    let label = option.label || option.value || option
+    const value = typeof option.value === 'undefined' ? option : option.value;
+    const label = typeof option.label === 'undefined' ? option : option.label;
 
     return (
       <div
         key={value}
         className={optionClass}
-        onMouseDown={this.setValue.bind(this, value, label)}
-        onClick={this.setValue.bind(this, value, label)}>
+        onMouseDown={this.setValue.bind(this, option)}
+        onClick={this.setValue.bind(this, option)}>
         {label}
       </div>
     )


### PR DESCRIPTION
Hi!
First of all, thanks for the good work on that component!

Like @Knovour in PR https://github.com/fraserxu/react-dropdown/pull/49 I need to be able to set a `value` of 0 for one of the choices. The current implementation does not allow this.

This PR also responds to:
- https://github.com/fraserxu/react-dropdown/issues/52: sending back the option without worrying about the content allows the `value` to be 0 (and the `label` as well)
- https://github.com/fraserxu/react-dropdown/issues/48 / https://github.com/fraserxu/react-dropdown/pull/54: the problem on the `is-selected` is addressed: now that the option is used, the equality check works
