### PR TITLE
bug fix for commit 94c9d8, which introduced an oscillation

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,8 @@ class Dropdown extends Component {
   componentWillReceiveProps (newProps) {
     if (newProps.value && newProps.value !== this.state.selected) {
       this.setState({selected: newProps.value})
-    } else if (!newProps.value && newProps.placeholder) {
-      this.setState({selected: { label: newProps.placeholder, value: '' }})
-    } else {
-      this.setState({selected: { label: DEFAULT_PLACEHOLDER_STRING, value: '' }})
+    } else if (!newProps.value) {
+        this.setState({selected: { label: newProps.placeholder || DEFAULT_PLACEHOLDER_STRING, value: '' }})
     }
   }
 


### PR DESCRIPTION

The code would clear the placeholder test to empty string when trying to
set the selection to the same value it was already set to.

Normally this would be an un-noticeable bug, but on a complex render
with other timers this shows as a flicker as the text transitions from
the placeholder text (Select...) to the correct text.