### PR TITLE
Bugfix - Crash when not supplying onFocus prop

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79,7 +79,9 @@ var Dropdown = function (_Component) {
   }, {
     key: 'handleMouseDown',
     value: function handleMouseDown(event) {
-      this.props.onFocus(this.state.isOpen);
+      if (this.props.onFocus && typeof this.props.onFocus === 'function') {
+        this.props.onFocus(this.state.isOpen);
+      }
       if (event.type === 'mousedown' && event.button !== 0) return;
       event.stopPropagation();
       event.preventDefault();

--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@ class Dropdown extends Component {
   }
 
   handleMouseDown (event) {
-    this.props.onFocus(this.state.isOpen)
+    if (this.props.onFocus && typeof this.props.onFocus === 'function') {
+      this.props.onFocus(this.state.isOpen)
+    }
     if (event.type === 'mousedown' && event.button !== 0) return
     event.stopPropagation()
     event.preventDefault()


### PR DESCRIPTION
This PR should fix a bug introduced by #60 , where the dropdown would crash if the `onFocus` prop was not supplied.