### PR TITLE
Use baseClassName in disabled class

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -185,7 +185,7 @@ var Dropdown = function (_Component) {
 
       var baseClassName = this.props.baseClassName;
 
-      var disabledClass = this.props.disabled ? 'Dropdown-disabled' : '';
+      var disabledClass = this.props.disabled ? baseClassName + '-disabled' : '';
       var placeHolderValue = typeof this.state.selected === 'string' ? this.state.selected : this.state.selected.label;
       var value = _react2.default.createElement(
         'div',

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ class Dropdown extends Component {
 
   render () {
     const { baseClassName } = this.props
-    const disabledClass = this.props.disabled ? 'Dropdown-disabled' : ''
+    const disabledClass = this.props.disabled ? `${baseClassName}-disabled` : ''
     const placeHolderValue = typeof this.state.selected === 'string' ? this.state.selected : this.state.selected.label
     let value = (<div className={`${baseClassName}-placeholder`}>{placeHolderValue}</div>)
     let menu = this.state.isOpen ? <div className={`${baseClassName}-menu`}>{this.buildMenu()}</div> : null


### PR DESCRIPTION
Currently `baseClassName` is not used when building a class name for a disabled dropdown, it always equals to `.Dropdown-disabled`. This pull request fixes this behaviour.