### PR TITLE
Empty string as default value for className. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ class Dropdown extends Component {
 
 Dropdown.defaultProps = {
   baseClassName: 'Dropdown',
-  className:''
+  className: ''
 }
 
 export default Dropdown

--- a/index.js
+++ b/index.js
@@ -149,5 +149,9 @@ class Dropdown extends Component {
   }
 }
 
-Dropdown.defaultProps = { baseClassName: 'Dropdown' }
+Dropdown.defaultProps = {
+  baseClassName: 'Dropdown',
+  className:''
+}
+
 export default Dropdown


### PR DESCRIPTION
Having undefined default value for strings causes undefined to be stringified to "undefined".
Added className to defaultProps with empty string as value.
