### PR TITLE
performance: remove extra setState calls on document click

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,9 @@ class Dropdown extends Component {
   handleDocumentClick (event) {
     if (this.mounted) {
       if (!ReactDOM.findDOMNode(this).contains(event.target)) {
-        this.setState({ isOpen: false })
+        if (this.state.isOpen) {
+          this.setState({ isOpen: false })
+        }
       }
     }
   }


### PR DESCRIPTION
setState with object literal makes react run reconciliation. Reconciliation takes  ~1ms but I have more than 200 dropdowns on the page so this issue costs me 200ms per each click anywhere on the page.