### PR TITLE
*actually* include TypeScript declarations file in npm repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "dist/index.js",
+    "index.d.ts",
     "style.css"
   ],
   "keywords": [


### PR DESCRIPTION
Thanks for being the only React dropdown component (that I found so far) that *actually* included a TypeScript declarations file! However, it wasn't included properly in the final published package. :c

This PR should fix it.