### PR TITLE
[TypeScript] typings improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 declare module "react-dropdown" {
   import * as React from "react";
-  interface Option {
+  export interface Option {
     label: string;
     value: string;
   }
-  interface Group {
+  export interface Group {
     type: "group";
     name: string;
     items: Option[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,8 +11,8 @@ declare module "react-dropdown" {
   }
   interface ReactDropdownProps {
     options: (Group | Option)[];
-    baseClassName: string;
-    className: string;
+    baseClassName?: string;
+    className?: string;
     disabled?: boolean;
     onChange?: (arg: Option) => void;
     onFocus?: (arg: boolean) => void;


### PR DESCRIPTION
I'm planning a few typings improvements in this PR, so I'm currently tagging it as a WIP.

### One.

I've exported both the `Option` and `Group` interfaces so we can correctly type the passed `options` prop without any typing errors.

```tsx
import Dropdown, { Option, Group } from 'react-dropdown'

const options: (Option | Group)[] = [
  { value: 'one', label: 'One' },
  { value: 'two', label: 'Two' },
  {
   type: 'group', name: 'group1', items: [
     { value: 'three', label: 'Three' },
     { value: 'four', label: 'Four' }
   ]
  },
  {
   type: 'group', name: 'group2', items: [
     { value: 'five', label: 'Five' },
     { value: 'six', label: 'Six' }
   ]
  }
]

<Dropdown options={options} {...otherProps} />
```

### Two.

I've also performed a quick look through the props used by ReactDropdown so that optional and mandatory props are properly marked.