### PR TITLE
Fixed missing arrowClassName prop in typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare module "react-dropdown" {
     className?: string;
     placeholderClassName?: string;
     menuClassName?: string;
+    arrowClassName?: string;
     disabled?: boolean;
     onChange?: (arg: Option) => void;
     onFocus?: (arg: boolean) => void;


### PR DESCRIPTION
Hi,
...because: https://github.com/fraserxu/react-dropdown/blob/5773035ea0d5e7d581de82265a37a77c9d1cc429/index.js#L135