### PR TITLE
Custom arrows, is-selected class on placeholder, and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ The `arrowClassName` prop is passed down to the arrow `span` , which also has th
 <Dropdown arrowClassName='myArrowClassName' />
 ```
 
+The `arrowClosed` & `arrowOpen` props enable passing in custom elements for the open/closed state arrows.
+
+```JavaScript
+<Dropdown
+  arrowClosed={<span className="arrow-closed" />}
+  arrowOpen={<span className="arrow-open" />}
+/>
+```
+
 Check more examples in the example folder.
 
 **Run example**

--- a/dist/index.js
+++ b/dist/index.js
@@ -186,6 +186,11 @@ var Dropdown = function (_Component) {
       }
     }
   }, {
+    key: 'isValueSelected',
+    value: function isValueSelected() {
+      return typeof this.state.selected === 'string' || this.state.selected.value !== '';
+    }
+  }, {
     key: 'render',
     value: function render() {
       var _classNames, _classNames2, _classNames3, _classNames4, _classNames5;
@@ -204,7 +209,7 @@ var Dropdown = function (_Component) {
 
       var dropdownClass = (0, _classnames2.default)((_classNames = {}, _defineProperty(_classNames, baseClassName + '-root', true), _defineProperty(_classNames, className, !!className), _defineProperty(_classNames, 'is-open', this.state.isOpen), _classNames));
       var controlClass = (0, _classnames2.default)((_classNames2 = {}, _defineProperty(_classNames2, baseClassName + '-control', true), _defineProperty(_classNames2, controlClassName, !!controlClassName), _defineProperty(_classNames2, disabledClass, !!disabledClass), _classNames2));
-      var placeholderClass = (0, _classnames2.default)((_classNames3 = {}, _defineProperty(_classNames3, baseClassName + '-placeholder', true), _defineProperty(_classNames3, placeholderClassName, !!placeholderClassName), _classNames3));
+      var placeholderClass = (0, _classnames2.default)((_classNames3 = {}, _defineProperty(_classNames3, baseClassName + '-placeholder', true), _defineProperty(_classNames3, placeholderClassName, !!placeholderClassName), _defineProperty(_classNames3, 'is-selected', this.isValueSelected()), _classNames3));
       var menuClass = (0, _classnames2.default)((_classNames4 = {}, _defineProperty(_classNames4, baseClassName + '-menu', true), _defineProperty(_classNames4, menuClassName, !!menuClassName), _classNames4));
       var arrowClass = (0, _classnames2.default)((_classNames5 = {}, _defineProperty(_classNames5, baseClassName + '-arrow', true), _defineProperty(_classNames5, arrowClassName, !!arrowClassName), _classNames5));
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -201,6 +201,8 @@ var Dropdown = function (_Component) {
           placeholderClassName = _props2.placeholderClassName,
           menuClassName = _props2.menuClassName,
           arrowClassName = _props2.arrowClassName,
+          arrowClosed = _props2.arrowClosed,
+          arrowOpen = _props2.arrowOpen,
           className = _props2.className;
 
 
@@ -231,7 +233,11 @@ var Dropdown = function (_Component) {
           'div',
           { className: controlClass, onMouseDown: this.handleMouseDown.bind(this), onTouchEnd: this.handleMouseDown.bind(this) },
           value,
-          _react2.default.createElement('span', { className: arrowClass })
+          _react2.default.createElement(
+            'div',
+            { className: baseClassName + '-arrow-wrapper' },
+            arrowOpen && arrowClosed ? this.state.isOpen ? arrowOpen : arrowClosed : _react2.default.createElement('span', { className: arrowClass })
+          )
         ),
         menu
       );

--- a/dist/index.js
+++ b/dist/index.js
@@ -117,15 +117,15 @@ var Dropdown = function (_Component) {
     value: function renderOption(option) {
       var _classes;
 
-      var classes = (_classes = {}, _defineProperty(_classes, this.props.baseClassName + '-option', true), _defineProperty(_classes, option.className, !!option.className), _defineProperty(_classes, 'is-selected', option === this.state.selected), _classes);
-
-      var optionClass = (0, _classnames2.default)(classes);
-
       var value = option.value;
       if (typeof value === 'undefined') {
         value = option.label || option;
       }
       var label = option.label || option.value || option;
+
+      var classes = (_classes = {}, _defineProperty(_classes, this.props.baseClassName + '-option', true), _defineProperty(_classes, option.className, !!option.className), _defineProperty(_classes, 'is-selected', value === this.state.selected.value || value === this.state.selected), _classes);
+
+      var optionClass = (0, _classnames2.default)(classes);
 
       return _react2.default.createElement(
         'div',

--- a/dist/index.js
+++ b/dist/index.js
@@ -39,7 +39,7 @@ var Dropdown = function (_Component) {
     var _this = _possibleConstructorReturn(this, (Dropdown.__proto__ || Object.getPrototypeOf(Dropdown)).call(this, props));
 
     _this.state = {
-      selected: props.value || {
+      selected: _this.parseValue(props.value, props.options) || {
         label: typeof props.placeholder === 'undefined' ? DEFAULT_PLACEHOLDER_STRING : props.placeholder,
         value: ''
       },
@@ -91,6 +91,28 @@ var Dropdown = function (_Component) {
           isOpen: !this.state.isOpen
         });
       }
+    }
+  }, {
+    key: 'parseValue',
+    value: function parseValue(value, options) {
+      var option = undefined;
+
+      if (typeof value === 'string') {
+        for (var i = 0, num = options.length; i < num; i++) {
+          if (options[i].type === 'group') {
+            var match = options[i].items.filter(function (item) {
+              return item.value === value;
+            });
+            if (match.length) {
+              option = match[0];
+            }
+          } else if (typeof options[i].value !== 'undefined' && options[i].value === value) {
+            option = options[i];
+          }
+        }
+      }
+
+      return option || value;
     }
   }, {
     key: 'setValue',

--- a/example/customArrowExample.js
+++ b/example/customArrowExample.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react'
+import Dropdown from '../index.js'
+
+const options = [
+  'one', 'two', 'three'
+]
+
+const arrowClosed = (
+  <span className="arrow-closed" />
+)
+const arrowOpen = (
+  <span className="arrow-open" />
+)
+
+class CustomArrowExample extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      selected: ''
+    }
+  }
+
+  render () {
+    const defaultOption = this.state.selected
+
+    return (
+      <section>
+        <h3>Custom Arrow Example</h3>
+        <Dropdown
+          arrowClosed={arrowClosed}
+          arrowOpen={arrowOpen}
+          options={options}
+          value={defaultOption}
+          placeholder="Select an option"
+        />
+
+        <section>
+          <h4>Usage: </h4>
+          <div className='code'>
+            <pre>
+              {`
+const arrowClosed = (
+  <span className="arrow-closed" />
+)
+const arrowOpen = (
+  <span className="arrow-open" />
+)
+
+<Dropdown
+  arrowClosed={arrowClosed}
+  arrowOpen={arrowOpen}
+  options={options}
+  value={defaultOption}
+  placeholder="Select an option"
+/>
+              `}
+            </pre>
+          </div>
+        </section>
+      </section>
+    )
+  }
+}
+
+export default CustomArrowExample

--- a/example/flatArrayExample.js
+++ b/example/flatArrayExample.js
@@ -9,7 +9,7 @@ class FlatArrayExample extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      selected: options[0]
+      selected: ''
     }
     this._onSelect = this._onSelect.bind(this)
   }

--- a/example/main.js
+++ b/example/main.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 import FlatArrayExample from './flatArrayExample'
 import ObjectArrayExample from './objectArrayExample'
 import ZeroValObjectArrayExample from './zeroValObjectArrayExample'
+import CustomArrowExample from './CustomArrowExample'
 
 class App extends Component {
   render () {
@@ -38,6 +39,7 @@ class App extends Component {
         <FlatArrayExample />
         <ObjectArrayExample />
         <ZeroValObjectArrayExample />
+        <CustomArrowExample />
 
         <section>
           <h3>License: </h3>

--- a/example/style.css
+++ b/example/style.css
@@ -23,6 +23,27 @@ pre code {
   padding: 8px 0;
 }
 
+.arrow-closed, .arrow-open {
+  border: solid #999;
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 4px;
+  position: absolute;
+  right: 10px;
+}
+
+.arrow-closed {
+  top: 10px;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+}
+
+.arrow-open {
+  top: 14px;
+  transform: rotate(-135deg);
+  -webkit-transform: rotate(-135deg);
+}
+
 .Dropdown-root {
   position: relative;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare module "react-dropdown" {
     name: string;
     items: Option[];
   }
-  interface ReactDropdownProps {
+  export interface ReactDropdownProps {
     options: (Group | Option | string)[];
     baseClassName?: string;
     className?: string;
@@ -21,7 +21,7 @@ declare module "react-dropdown" {
     disabled?: boolean;
     onChange?: (arg: Option) => void;
     onFocus?: (arg: boolean) => void;
-    value?: Option;
+    value?: Option | string;
     placeholder?: String;
   }
 

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ class Dropdown extends Component {
   }
 
   render () {
-    const { baseClassName, controlClassName, placeholderClassName, menuClassName, arrowClassName, className } = this.props
+    const { baseClassName, controlClassName, placeholderClassName, menuClassName, arrowClassName, arrowClosed, arrowOpen, className } = this.props
 
     const disabledClass = this.props.disabled ? 'Dropdown-disabled' : ''
     const placeHolderValue = typeof this.state.selected === 'string' ? this.state.selected : this.state.selected.label
@@ -172,7 +172,13 @@ class Dropdown extends Component {
       <div className={dropdownClass}>
         <div className={controlClass} onMouseDown={this.handleMouseDown.bind(this)} onTouchEnd={this.handleMouseDown.bind(this)}>
           {value}
-          <span className={arrowClass} />
+          <div className={`${baseClassName}-arrow-wrapper`}>
+            { arrowOpen && arrowClosed ?
+              this.state.isOpen ? arrowOpen : arrowClosed
+              :
+              <span className={arrowClass} />
+            }
+          </div>
         </div>
         {menu}
       </div>

--- a/index.js
+++ b/index.js
@@ -57,22 +57,22 @@ class Dropdown extends Component {
   }
 
   parseValue (value, options) {
-    let option = undefined;
+    let option = undefined
 
     if (typeof value === 'string') {
       for (var i = 0, num = options.length; i < num; i++) {
         if (options[i].type === 'group') {
           const match = options[i].items.filter(item => item.value === value)
           if (match.length) {
-            option = match[0];
+            option = match[0]
           }
         } else if (typeof options[i].value !== 'undefined' && options[i].value === value) {
-          option = options[i];
+          option = options[i]
         }
       }
     }
 
-    return option || value;
+    return option || value
   }
 
   setValue (value, label) {
@@ -151,7 +151,7 @@ class Dropdown extends Component {
   }
 
   isValueSelected () {
-    return typeof this.state.selected === 'string' || this.state.selected.value !== '';
+    return typeof this.state.selected === 'string' || this.state.selected.value !== ''
   }
 
   render () {

--- a/index.js
+++ b/index.js
@@ -131,6 +131,10 @@ class Dropdown extends Component {
     }
   }
 
+  isValueSelected () {
+    return typeof this.state.selected === 'string' || this.state.selected.value !== '';
+  }
+
   render () {
     const { baseClassName, controlClassName, placeholderClassName, menuClassName, arrowClassName, className } = this.props
 
@@ -149,7 +153,8 @@ class Dropdown extends Component {
     })
     const placeholderClass = classNames({
       [`${baseClassName}-placeholder`]: true,
-      [placeholderClassName]: !!placeholderClassName
+      [placeholderClassName]: !!placeholderClassName,
+      'is-selected': this.isValueSelected()
     })
     const menuClass = classNames({
       [`${baseClassName}-menu`]: true,

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ class Dropdown extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      selected: props.value || {
+      selected: this.parseValue(props.value, props.options) || {
         label: typeof props.placeholder === 'undefined' ? DEFAULT_PLACEHOLDER_STRING : props.placeholder,
         value: ''
       },
@@ -54,6 +54,25 @@ class Dropdown extends Component {
         isOpen: !this.state.isOpen
       })
     }
+  }
+
+  parseValue (value, options) {
+    let option = undefined;
+
+    if (typeof value === 'string') {
+      for (var i = 0, num = options.length; i < num; i++) {
+        if (options[i].type === 'group') {
+          const match = options[i].items.filter(item => item.value === value)
+          if (match.length) {
+            option = match[0];
+          }
+        } else if (typeof options[i].value !== 'undefined' && options[i].value === value) {
+          option = options[i];
+        }
+      }
+    }
+
+    return option || value;
   }
 
   setValue (value, label) {

--- a/index.js
+++ b/index.js
@@ -75,19 +75,19 @@ class Dropdown extends Component {
   }
 
   renderOption (option) {
-    const classes = {
-      [`${this.props.baseClassName}-option`]: true,
-      [option.className]: !!option.className,
-      'is-selected': option === this.state.selected
-    }
-
-    const optionClass = classNames(classes)
-
     let value = option.value
     if (typeof value === 'undefined') {
       value = option.label || option
     }
     let label = option.label || option.value || option
+
+    const classes = {
+      [`${this.props.baseClassName}-option`]: true,
+      [option.className]: !!option.className,
+      'is-selected': value === this.state.selected.value || value === this.state.selected
+    }
+
+    const optionClass = classNames(classes)
 
     return (
       <div


### PR DESCRIPTION
This PR includes the following:

1. Enables passing in custom arrow elements via `arrowOpen` & `arrowClosed` props, with example provided, and updated readme (#133)
2. Adds the `is-selected` class to `.Dropdown-placeholder` when an option is selected, enabling  selected/unselected styling of the placeholder (#137)
3. Enables lookup by value vs full object, and sets `this.selected` to the corresponding object.
Currently when `options` is an array of option objects `{ value: 'foo', label: 'Foo'}`, and `value` is  a string (`<Dropdown value="foo" />`), `this.selected` is set to `foo` instead of `{ value: 'foo', label: 'Foo'}`. (#78)
4. Fixes `is-selected` class not getting applied to a selected option `(#54 #99, #110, #124)
5. Updates typings
Exports `ReactDropdownProps` for import where needed
Updates `value` prop to also accept `string`