### PR TITLE
Call parseValue for selected state when value changes #141

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -54,9 +54,12 @@ var Dropdown = function (_Component) {
   _createClass(Dropdown, [{
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(newProps) {
-      if (newProps.value && newProps.value !== this.state.selected) {
-        this.setState({ selected: newProps.value });
-      } else if (!newProps.value) {
+      if (newProps.value) {
+        var selected = this.parseValue(newProps.value, newProps.options);
+        if (selected !== this.state.selected) {
+          this.setState({ selected: selected });
+        }
+      } else {
         this.setState({ selected: {
             label: typeof newProps.placeholder === 'undefined' ? DEFAULT_PLACEHOLDER_STRING : newProps.placeholder,
             value: ''

--- a/index.js
+++ b/index.js
@@ -20,9 +20,12 @@ class Dropdown extends Component {
   }
 
   componentWillReceiveProps (newProps) {
-    if (newProps.value && newProps.value !== this.state.selected) {
-      this.setState({selected: newProps.value})
-    } else if (!newProps.value) {
+    if (newProps.value) {
+      var selected = this.parseValue(newProps.value, newProps.options)
+      if (selected !== this.state.selected) {
+        this.setState({selected: selected})
+      }
+    } else {
       this.setState({selected: {
         label: typeof newProps.placeholder === 'undefined' ? DEFAULT_PLACEHOLDER_STRING : newProps.placeholder,
         value: ''


### PR DESCRIPTION
#141 

Call `parseValue` when setting `selected` state in `componentWillReceiveProps`.

This handles the case where `newProps.value` is just the string value, rather than an object containing the label and value.  (This can happen, for example, with Redux Form when the Field component has a normalize function that does `({ value }) => value`.)