### PR TITLE
Sets option label type to accept ReactNode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare module "react-dropdown" {
   import * as React from "react";
   export interface Option {
-    label: string;
+    label: React.ReactNode;
     value: string;
     className?: string;
   }


### PR DESCRIPTION
This leads to better customisation, one can now use string as before or JSX.Element, JSX.Element[], React Fragment...