### PR TITLE
Remove deprecated ReactDOM.findDOMNode

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7,8 +7,6 @@ exports["default"] = void 0;
 
 var _react = _interopRequireWildcard(require("react"));
 
-var _reactDom = _interopRequireDefault(require("react-dom"));
-
 var _classnames = _interopRequireDefault(require("classnames"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
@@ -57,6 +55,7 @@ function (_Component) {
       },
       isOpen: false
     };
+    _this.dropdownRef = (0, _react.createRef)();
     _this.mounted = true;
     _this.handleDocumentClick = _this.handleDocumentClick.bind(_assertThisInitialized(_this));
     _this.fireChangeEvent = _this.fireChangeEvent.bind(_assertThisInitialized(_this));
@@ -218,7 +217,7 @@ function (_Component) {
     key: "handleDocumentClick",
     value: function handleDocumentClick(event) {
       if (this.mounted) {
-        if (!_reactDom["default"].findDOMNode(this).contains(event.target)) {
+        if (!this.dropdownRef.current.contains(event.target)) {
           if (this.state.isOpen) {
             this.setState({
               isOpen: false
@@ -263,6 +262,7 @@ function (_Component) {
         "aria-expanded": "true"
       }, this.buildMenu()) : null;
       return _react["default"].createElement("div", {
+        ref: this.dropdownRef,
         className: dropdownClass
       }, _react["default"].createElement("div", {
         className: controlClass,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-import React, { Component } from 'react'
-import ReactDOM from 'react-dom'
+import React, { Component, createRef } from 'react'
 import classNames from 'classnames'
 
 const DEFAULT_PLACEHOLDER_STRING = 'Select...'
@@ -14,6 +13,7 @@ class Dropdown extends Component {
       },
       isOpen: false
     }
+    this.dropdownRef = createRef()
     this.mounted = true
     this.handleDocumentClick = this.handleDocumentClick.bind(this)
     this.fireChangeEvent = this.fireChangeEvent.bind(this)
@@ -155,7 +155,7 @@ class Dropdown extends Component {
 
   handleDocumentClick (event) {
     if (this.mounted) {
-      if (!ReactDOM.findDOMNode(this).contains(event.target)) {
+      if (!this.dropdownRef.current.contains(event.target)) {
         if (this.state.isOpen) {
           this.setState({ isOpen: false })
         }
@@ -205,7 +205,7 @@ class Dropdown extends Component {
     </div> : null
 
     return (
-      <div className={dropdownClass}>
+      <div ref={this.dropdownRef} className={dropdownClass}>
         <div className={controlClass} onMouseDown={this.handleMouseDown.bind(this)} onTouchEnd={this.handleMouseDown.bind(this)} aria-haspopup='listbox'>
           {value}
           <div className={`${baseClassName}-arrow-wrapper`}>


### PR DESCRIPTION
Replaced React.findDOMNode which is deprecated in strict mode with Ref.