### PR TITLE
Add npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+      - run: npm install --global npm@11.18.0
+      - run: npm ci
+      - name: Publish to npm
+        shell: bash
+        run: |
+          version=$(node -p "require('./package.json').version")
+          if [[ "$version" == *-* ]]; then
+            dist_tag=next
+          else
+            dist_tag=latest
+          fi
+          npm publish --access public --provenance --tag "$dist_tag"


### PR DESCRIPTION
## Summary

- add a release-triggered npm publishing workflow matching react-chartist
- authenticate npm publishing with GitHub OIDC instead of a long-lived `NPM_TOKEN`
- publish stable versions to `latest` and prerelease versions to `next`
- publish public packages with provenance

## How it works

Publishing a GitHub Release triggers `.github/workflows/release.yml`. The workflow:

1. grants only `contents: read` and `id-token: write`
2. checks out the tagged release on a GitHub-hosted runner
3. uses Node 24 and npm 11.18.0
4. runs `npm ci`
5. publishes the package with the appropriate npm dist-tag

This mirrors fraserxu/react-chartist's trusted-publishing workflow and does not use an npm token secret.

## Required npm configuration after merge

Configure the `react-dropdown` package's trusted publisher on npm with:

- Provider: GitHub Actions
- Organization or user: `fraserxu`
- Repository: `react-dropdown`
- Workflow filename: `release.yml`
- Environment: leave blank
- Allowed action: `npm publish`

The workflow filename and repository fields are case-sensitive.

## Validation

- `npm run check`
- 12 interaction and SSR tests pass
- TypeScript and ESM/CommonJS builds pass
- `npm pack --dry-run --json` succeeds for `react-dropdown@2.0.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no runtime or library code touched; npm publish still requires matching trusted-publisher setup on npm after merge.
> 
> **Overview**
> Adds **release-triggered npm publishing** via a new `.github/workflows/release.yml` workflow that runs when a GitHub Release is published.
> 
> Publishing uses **npm trusted publishing** (GitHub OIDC with `id-token: write`) instead of a stored `NPM_TOKEN`. The job checks out the tag, runs `npm ci` on Node 24, then publishes with `--access public --provenance`, choosing **`latest`** for stable versions and **`next`** for prerelease versions (semver contains `-`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c63aa84d7e5fd398c157c6a5634ecd950426a46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->