### PR TITLE
Fix release clean install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           cache: npm
           node-version: "24"
           registry-url: https://registry.npmjs.org
-      - run: npm install --global npm@11.18.0
+      - run: npm install --global npm@11.6.1
       - run: npm ci
       - name: Publish to npm
         shell: bash


### PR DESCRIPTION
## What changed

- Pin the release workflow to npm 11.6.1, matching the version used by the green CI matrix.

## Why

The v2.0.0 release run installed npm 11.18.0, then failed during `npm ci` because that npm version rejected the existing lockfile's optional `@emnapi` dependency resolution. The publish step never ran.

## Impact

Release-triggered installs can complete again, allowing trusted publishing to reach `npm publish`.

## Validation

- `npm ci` with Node 24.10.0 and npm 11.6.1
- `npm run check` (typecheck, 12 tests, build)
- `npm pack --dry-run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow version pin with no application or dependency logic changes.
> 
> **Overview**
> The release workflow’s global npm install is **downgraded from 11.18.0 to 11.6.1**, aligning with the version already pinned in the CI matrix.
> 
> This avoids `npm ci` failing on publish (e.g. v2.0.0) when newer npm rejects the lockfile’s optional `@emnapi` resolution, so the publish step can run again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957f8184edcacfa7ffdc1f306816b5e6003c12e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->