### PR TITLE
Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # react-dropdown
 
+[![npm](https://img.shields.io/npm/v/react-dropdown.svg)](https://www.npmjs.com/package/react-dropdown)
+[![CI](https://github.com/fraserxu/react-dropdown/actions/workflows/ci.yml/badge.svg)](https://github.com/fraserxu/react-dropdown/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/react-dropdown.svg)](LICENSE)
+
 A lightweight, accessible dropdown component for React 18 and 19.
 
 `react-dropdown` is for the common case where a native `<select>` is too difficult to style, but a large select framework would be excessive. It supports single selection, option groups, controlled and uncontrolled state, custom rendering, keyboard navigation, and TypeScript without runtime dependencies.


### PR DESCRIPTION
## What changed

- Add an npm version badge linked to the `react-dropdown` package.
- Add a GitHub Actions CI badge linked to this repository's `ci.yml` workflow.
- Add an npm license badge linked to `LICENSE`.

## Why

This makes the package version, build status, and license visible at the top of the README.

## Impact

Documentation-only change. All badge URLs and package references use `react-dropdown`.

## Validation

- `git diff --check`
- Confirmed no `react-chartist` references are present in the added badges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no code or dependency impact.
> 
> **Overview**
> Adds three shields.io badges directly under the README title: **npm version** (linked to the package on npm), **CI** (linked to the repository’s GitHub Actions `ci.yml` workflow), and **license** (linked to `LICENSE`).
> 
> No runtime or API changes—README visibility only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8ca5d0c919640c0133be261417acc4f6ba3b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->