### PR TITLE
Rebuild demo site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy demo
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm install --global npm@11.6.1
+      - run: npm ci
+      - run: npm run build:demo
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: demo-dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/Release
 node_modules
 
 example/bundle.js
+demo-dist
 
 # This project doesn't use Yarn
 yarn.lock

--- a/example/index.html
+++ b/example/index.html
@@ -3,7 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>react-dropdown 2.0</title>
+    <meta
+      name="description"
+      content="A lightweight, accessible dropdown component for React 18 and 19."
+    />
+    <meta name="theme-color" content="#11172b" />
+    <meta property="og:title" content="react-dropdown — One control. Zero choreography." />
+    <meta
+      property="og:description"
+      content="A lightweight, accessible dropdown for the space between a native select and a full-scale UI framework."
+    />
+    <title>react-dropdown — Accessible dropdown for React</title>
   </head>
   <body>
     <div id="root"></div>

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -4,38 +4,301 @@ import Dropdown, { type Option } from '../../src/index'
 import '../../style.css'
 import './style.css'
 
-const options = [
-  { value: 'design', label: 'Design' },
-  { value: 'engineering', label: 'Engineering' },
+const workspaceOptions = [
   {
     type: 'group' as const,
-    name: 'Operations',
+    name: 'Workspace',
     items: [
-      { value: 'finance', label: 'Finance' },
-      { value: 'legal', label: 'Legal', disabled: true },
+      { value: 'overview', label: 'Overview', data: { tone: 'blue' } },
+      { value: 'roadmap', label: 'Roadmap', data: { tone: 'orange' } },
+      { value: 'releases', label: 'Releases', data: { tone: 'mint' } },
+    ],
+  },
+  {
+    type: 'group' as const,
+    name: 'Project',
+    items: [
+      { value: 'activity', label: 'Activity', data: { tone: 'violet' } },
+      { value: 'settings', label: 'Settings', data: { tone: 'slate' } },
+      { value: 'archive', label: 'Archive', disabled: true, data: { tone: 'slate' } },
     ],
   },
 ]
 
+const featureCards = [
+  {
+    marker: '⌘',
+    title: 'Keyboard complete',
+    body: 'Arrow keys, Home, End, Enter, Escape, and Tab work the way people expect.',
+  },
+  {
+    marker: 'Aa',
+    title: 'Typed by default',
+    body: 'TypeScript definitions ship with the package, including groups and custom renderers.',
+  },
+  {
+    marker: '0',
+    title: 'No runtime baggage',
+    body: 'Just React. No positioning engine, style framework, or extra production dependency.',
+  },
+]
+
+const installCommand = 'npm install react-dropdown'
+
+function GitHubIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      <path
+        fill="currentColor"
+        d="M12 .7a11.5 11.5 0 0 0-3.64 22.4c.58.1.79-.25.79-.56v-2.22c-3.22.7-3.9-1.36-3.9-1.36-.52-1.34-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.57-.3-5.28-1.29-5.28-5.69 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.17 1.18a10.9 10.9 0 0 1 5.78 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.83 1.19 3.09 0 4.42-2.71 5.39-5.29 5.68.42.36.79 1.06.79 2.14v3.18c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z"
+      />
+    </svg>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 20 20">
+      <path d="m4 10 4 4 8-9" />
+    </svg>
+  )
+}
+
+function ArrowIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 20 20">
+      <path d="M4 10h12M11 5l5 5-5 5" />
+    </svg>
+  )
+}
+
 function App() {
-  const [selected, setSelected] = useState<Option | null>(null)
+  const [selected, setSelected] = useState<Option | null>({
+    value: 'overview',
+    label: 'Overview',
+    data: { tone: 'blue' },
+  })
+  const [copied, setCopied] = useState(false)
+
+  const copyInstallCommand = async () => {
+    await navigator.clipboard.writeText(installCommand)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1600)
+  }
+
+  const selectedLabel = typeof selected?.label === 'string' ? selected.label : 'Nothing selected'
+  const selectedTone = String(selected?.data?.tone ?? 'blue')
 
   return (
-    <main>
-      <p className="eyebrow">react-dropdown 2.0</p>
-      <h1>A small dropdown that behaves like a real control.</h1>
-      <p className="intro">Try it with a pointer, Tab, arrow keys, Enter, and Escape.</p>
-      <label id="team-label">Team</label>
-      <Dropdown
-        aria-labelledby="team-label"
-        options={options}
-        value={selected}
-        onChange={setSelected}
-        placeholder="Choose a team"
-        name="team"
-      />
-      <output>{selected ? `Selected: ${selected.label}` : 'Nothing selected'}</output>
-    </main>
+    <div className="site-shell">
+      <header className="site-header">
+        <a className="wordmark" href="#top" aria-label="react-dropdown home">
+          <span className="wordmark-mark" aria-hidden="true">
+            ↓
+          </span>
+          <span>react-dropdown</span>
+        </a>
+        <nav aria-label="Primary navigation">
+          <a href="#features">Features</a>
+          <a href="#example">Example</a>
+          <a
+            className="github-link"
+            href="https://github.com/fraserxu/react-dropdown"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <GitHubIcon />
+            <span>GitHub</span>
+          </a>
+        </nav>
+      </header>
+
+      <main id="top">
+        <section className="hero" aria-labelledby="hero-title">
+          <div className="hero-copy">
+            <p className="eyebrow">
+              <span>v2.0</span>
+              React 18 + 19
+            </p>
+            <h1 id="hero-title">
+              One control.
+              <br />
+              <em>Zero choreography.</em>
+            </h1>
+            <p className="lede">
+              A lightweight, accessible dropdown for the space between a native select and a
+              full-scale UI framework.
+            </p>
+            <div className="install-row">
+              <button className="install-command" type="button" onClick={copyInstallCommand}>
+                <span aria-hidden="true">$</span>
+                <code>{installCommand}</code>
+                <span className="copy-label" aria-live="polite">
+                  {copied ? 'Copied' : 'Copy'}
+                </span>
+              </button>
+              <a className="text-link" href="#example">
+                See the code <ArrowIcon />
+              </a>
+            </div>
+            <ul className="proof-list" aria-label="Package highlights">
+              <li>
+                <CheckIcon /> Accessible
+              </li>
+              <li>
+                <CheckIcon /> TypeScript
+              </li>
+              <li>
+                <CheckIcon /> Zero dependencies
+              </li>
+            </ul>
+          </div>
+
+          <div className="control-lab" aria-label="Interactive dropdown demo">
+            <div className="lab-toolbar">
+              <span className="lab-status">
+                <i /> Live control
+              </span>
+              <span>Try the keyboard</span>
+            </div>
+            <div className="lab-stage">
+              <div className="field-block">
+                <div className="field-heading">
+                  <label id="view-label">Project view</label>
+                  <span>Required</span>
+                </div>
+                <Dropdown
+                  aria-labelledby="view-label"
+                  aria-required
+                  options={workspaceOptions}
+                  value={selected}
+                  onChange={setSelected}
+                  placeholder="Choose a view"
+                  name="project-view"
+                  renderOption={(option, state) => (
+                    <span className="option-content">
+                      <i className={`tone-dot tone-${String(option.data?.tone ?? 'slate')}`} />
+                      <span>{option.label}</span>
+                      {state.selected ? <span className="option-check">Selected</span> : null}
+                    </span>
+                  )}
+                />
+              </div>
+
+              <div className="signal-line" aria-hidden="true">
+                <span />
+              </div>
+
+              <div className="state-output">
+                <div>
+                  <span>Selected value</span>
+                  <strong>{selectedLabel}</strong>
+                </div>
+                <code data-tone={selectedTone}>{`"${String(selected?.value ?? '')}"`}</code>
+              </div>
+            </div>
+            <div className="key-strip" aria-label="Supported keyboard commands">
+              <span>Navigate</span>
+              <kbd>↑</kbd>
+              <kbd>↓</kbd>
+              <span>Select</span>
+              <kbd>Enter</kbd>
+              <span>Close</span>
+              <kbd>Esc</kbd>
+            </div>
+          </div>
+        </section>
+
+        <section className="features-section" id="features" aria-labelledby="features-title">
+          <div className="section-heading">
+            <p className="section-kicker">Built for the common case</p>
+            <h2 id="features-title">Small API. Complete behavior.</h2>
+          </div>
+          <div className="feature-grid">
+            {featureCards.map((feature) => (
+              <article className="feature-card" key={feature.title}>
+                <span className="feature-marker" aria-hidden="true">
+                  {feature.marker}
+                </span>
+                <h3>{feature.title}</h3>
+                <p>{feature.body}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="code-section" id="example" aria-labelledby="example-title">
+          <div className="code-copy">
+            <p className="section-kicker">Readable on purpose</p>
+            <h2 id="example-title">Drop it in. Style it yours.</h2>
+            <p>
+              Primitive values and option objects work together. Add groups, controlled state,
+              custom rendering, or form integration only when you need them.
+            </p>
+            <a
+              className="docs-link"
+              href="https://github.com/fraserxu/react-dropdown#readme"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Read the full API <ArrowIcon />
+            </a>
+          </div>
+
+          <div className="code-window" aria-label="React usage example">
+            <div className="code-toolbar">
+              <div aria-hidden="true">
+                <i />
+                <i />
+                <i />
+              </div>
+              <span>ProjectView.tsx</span>
+              <span>TSX</span>
+            </div>
+            <pre>
+              <code>
+                <span className="code-blue">import</span> Dropdown{' '}
+                <span className="code-blue">from</span>{' '}
+                <span className="code-green">'react-dropdown'</span>
+                {'\n'}
+                <span className="code-blue">import</span>{' '}
+                <span className="code-green">'react-dropdown/style.css'</span>
+                {'\n\n'}
+                <span className="code-blue">const</span> options = [
+                {'\n  '}
+                <span className="code-green">'Overview'</span>,{' '}
+                <span className="code-green">'Roadmap'</span>,{' '}
+                <span className="code-green">'Releases'</span>
+                {'\n'}]
+                {'\n\n'}
+                <span className="code-violet">&lt;Dropdown</span>
+                {'\n  '}options={'{options}'}
+                {'\n  '}onChange={'{setView}'}
+                {'\n  '}placeholder=<span className="code-green">&quot;Choose a view&quot;</span>
+                {'\n'}
+                <span className="code-violet">/&gt;</span>
+              </code>
+            </pre>
+          </div>
+        </section>
+      </main>
+
+      <footer>
+        <div>
+          <span className="wordmark-mark" aria-hidden="true">
+            ↓
+          </span>
+          <p>
+            Open source, MIT licensed.
+            <br />
+            Built by Fraser Xu.
+          </p>
+        </div>
+        <a href="https://www.npmjs.com/package/react-dropdown" target="_blank" rel="noreferrer">
+          View on npm <ArrowIcon />
+        </a>
+      </footer>
+    </div>
   )
 }
 

--- a/example/src/style.css
+++ b/example/src/style.css
@@ -1,58 +1,877 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&display=swap');
+
 :root {
-  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
-  color: #172033;
-  background: #eef2ff;
+  color: #11172b;
+  background: #eef2fb;
+  font-family: 'Manrope', 'Avenir Next', 'Helvetica Neue', sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --ink: #11172b;
+  --muted: #5d6680;
+  --paper: #f8faff;
+  --white: #fff;
+  --blue: #3659e8;
+  --blue-dark: #2442ba;
+  --orange: #ff6a4d;
+  --mint: #7de2b8;
+  --violet: #a98df6;
+  --line: #cbd4e8;
+  --mono: 'DM Mono', 'SFMono-Regular', Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
-  display: grid;
+  min-width: 320px;
   min-height: 100vh;
   margin: 0;
-  place-items: center;
+  background:
+    linear-gradient(rgb(54 89 232 / 5%) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(54 89 232 / 5%) 1px, transparent 1px),
+    #eef2fb;
+  background-size: 40px 40px;
 }
 
-main {
-  width: min(420px, calc(100vw - 48px));
-  padding: 40px;
-  border: 1px solid rgb(15 23 42 / 8%);
-  border-radius: 20px;
-  background: white;
-  box-shadow: 0 24px 80px rgb(30 41 59 / 12%);
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
 }
 
-.eyebrow {
-  margin: 0 0 8px;
-  color: #4f46e5;
-  font-size: 0.75rem;
+button {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 3px solid var(--orange);
+  outline-offset: 4px;
+}
+
+.site-shell {
+  width: min(1440px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  overflow: hidden;
+  border-right: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+  background: rgb(248 250 255 / 90%);
+}
+
+.site-header {
+  display: flex;
+  min-height: 76px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 clamp(24px, 5vw, 76px);
+  border-bottom: 1px solid var(--line);
+  background: rgb(248 250 255 / 92%);
+  backdrop-filter: blur(14px);
+}
+
+.wordmark {
+  display: inline-flex;
+  align-items: center;
+  color: var(--ink);
+  font-size: 0.98rem;
   font-weight: 800;
-  letter-spacing: 0.12em;
+  letter-spacing: -0.035em;
+  text-decoration: none;
+}
+
+.wordmark-mark {
+  display: inline-grid;
+  width: 34px;
+  height: 34px;
+  margin-right: 11px;
+  border: 1px solid var(--ink);
+  background: var(--orange);
+  font-family: var(--mono);
+  font-weight: 500;
+  place-items: center;
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+nav {
+  display: flex;
+  align-items: center;
+  gap: clamp(18px, 3vw, 38px);
+}
+
+nav a {
+  color: #39415a;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+nav a:hover {
+  color: var(--blue);
+}
+
+.github-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.github-link svg {
+  width: 18px;
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  min-height: 650px;
+  grid-template-columns: minmax(0, 0.96fr) minmax(460px, 1.04fr);
+  border-bottom: 1px solid var(--line);
+}
+
+.hero::before {
+  position: absolute;
+  top: -1px;
+  left: clamp(24px, 5vw, 76px);
+  width: 112px;
+  height: 5px;
+  background: var(--blue);
+  content: '';
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 82px clamp(36px, 6vw, 92px) 82px clamp(24px, 5vw, 76px);
+}
+
+.eyebrow,
+.section-kicker {
+  margin: 0;
+  color: var(--blue-dark);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
 }
 
+.eyebrow span {
+  display: inline-block;
+  padding: 5px 8px;
+  margin-right: 10px;
+  background: var(--blue);
+  color: white;
+  letter-spacing: 0.04em;
+}
+
 h1 {
+  max-width: 690px;
+  margin: 26px 0 24px;
+  font-size: clamp(3.4rem, 6.1vw, 6.7rem);
+  font-weight: 800;
+  letter-spacing: -0.075em;
+  line-height: 0.9;
+}
+
+h1 em {
+  color: var(--blue);
+  font-style: normal;
+}
+
+.lede {
+  max-width: 620px;
   margin: 0;
-  font-size: clamp(2rem, 8vw, 3rem);
-  line-height: 1;
-  letter-spacing: -0.045em;
+  color: var(--muted);
+  font-size: clamp(1rem, 1.4vw, 1.15rem);
+  line-height: 1.72;
 }
 
-.intro {
-  margin: 18px 0 32px;
-  color: #64748b;
-  line-height: 1.6;
+.install-row {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  margin-top: 38px;
 }
 
-label {
-  display: block;
-  margin-bottom: 8px;
-  font-size: 0.875rem;
+.install-command {
+  display: flex;
+  min-width: min(100%, 350px);
+  min-height: 52px;
+  align-items: center;
+  padding: 0;
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: white;
+  cursor: pointer;
+  text-align: left;
+  box-shadow: 5px 5px 0 var(--orange);
+}
+
+.install-command > span:first-child {
+  align-self: stretch;
+  display: grid;
+  width: 42px;
+  border-right: 1px solid #39415a;
+  color: var(--mint);
+  font-family: var(--mono);
+  place-items: center;
+}
+
+.install-command code {
+  padding: 0 13px;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.copy-label {
+  margin-left: auto;
+  padding-right: 14px;
+  color: #aeb8d0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.install-command:hover .copy-label {
+  color: white;
+}
+
+.text-link,
+.docs-link,
+footer > a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 5px;
+}
+
+.text-link svg,
+.docs-link svg,
+footer > a svg {
+  width: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  transition: transform 160ms ease;
+}
+
+.text-link:hover svg,
+.docs-link:hover svg,
+footer > a:hover svg {
+  transform: translateX(4px);
+}
+
+.proof-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 13px 24px;
+  padding: 0;
+  margin: 34px 0 0;
+  color: #4a536c;
+  font-size: 0.72rem;
+  font-weight: 700;
+  list-style: none;
+}
+
+.proof-list li {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.proof-list svg {
+  width: 16px;
+  fill: none;
+  stroke: var(--blue);
+  stroke-linecap: square;
+  stroke-width: 2;
+}
+
+.control-lab {
+  display: grid;
+  min-width: 0;
+  grid-template-rows: auto 1fr auto;
+  margin: 46px clamp(24px, 4vw, 58px) 46px 0;
+  border: 1px solid #222b44;
+  background: #161d31;
+  color: white;
+  box-shadow: 14px 14px 0 #c8d2ee;
+}
+
+.lab-toolbar {
+  display: flex;
+  min-height: 54px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  border-bottom: 1px solid #303950;
+  color: #aeb8d0;
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.lab-status {
+  display: inline-flex;
+  align-items: center;
+  color: white;
+}
+
+.lab-status i {
+  width: 8px;
+  height: 8px;
+  margin-right: 9px;
+  border-radius: 50%;
+  background: var(--mint);
+  box-shadow: 0 0 0 4px rgb(125 226 184 / 10%);
+}
+
+.lab-stage {
+  display: flex;
+  min-height: 390px;
+  flex-direction: column;
+  justify-content: center;
+  padding: 46px clamp(24px, 5vw, 56px);
+  background:
+    radial-gradient(circle at 88% 10%, rgb(54 89 232 / 17%), transparent 26%),
+    linear-gradient(rgb(255 255 255 / 3%) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(255 255 255 / 3%) 1px, transparent 1px);
+  background-size: auto, 24px 24px, 24px 24px;
+}
+
+.field-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.field-heading label {
+  font-size: 0.8rem;
   font-weight: 700;
 }
 
-output {
-  display: block;
-  min-height: 1.5em;
-  margin-top: 20px;
-  color: #64748b;
-  font-size: 0.875rem;
+.field-heading span {
+  color: #8f9ab7;
+  font-family: var(--mono);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+}
+
+.control-lab .Dropdown-control {
+  min-height: 60px;
+  padding: 0 58px 0 18px;
+  border: 2px solid white;
+  border-radius: 0;
+  background: white;
+  color: var(--ink);
+  font-weight: 700;
+  box-shadow: 6px 6px 0 var(--blue);
+}
+
+.control-lab .Dropdown-control:hover:not(:disabled) {
+  border-color: var(--mint);
+}
+
+.control-lab .Dropdown-control:focus-visible {
+  border-color: var(--mint);
+  outline: 2px solid transparent;
+  box-shadow: 6px 6px 0 var(--mint);
+}
+
+.control-lab .Dropdown-arrow-wrapper {
+  width: 50px;
+}
+
+.control-lab .Dropdown-arrow {
+  border-width: 5px 5px 0;
+  border-color: var(--blue) transparent transparent;
+}
+
+.control-lab .Dropdown-menu {
+  top: calc(100% + 10px);
+  padding: 6px;
+  border: 1px solid #bdc9e6;
+  border-radius: 0;
+  background: white;
+  color: var(--ink);
+  box-shadow: 8px 8px 0 var(--blue);
+}
+
+.control-lab .Dropdown-title {
+  padding: 10px 10px 6px;
+  color: #747e99;
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
+}
+
+.control-lab .Dropdown-option {
+  padding: 10px;
+  color: var(--ink);
+  font-size: 0.78rem;
+}
+
+.control-lab .Dropdown-option.is-active {
+  background: #edf1ff;
+}
+
+.control-lab .Dropdown-option.is-selected {
+  color: var(--blue-dark);
+  font-weight: 800;
+}
+
+.control-lab .Dropdown-option.is-disabled {
+  color: #a8afc0;
+}
+
+.option-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tone-dot {
+  width: 9px;
+  height: 9px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #8993ab;
+}
+
+.tone-blue {
+  background: var(--blue);
+}
+
+.tone-orange {
+  background: var(--orange);
+}
+
+.tone-mint {
+  background: #36b987;
+}
+
+.tone-violet {
+  background: var(--violet);
+}
+
+.option-check {
+  margin-left: auto;
+  color: var(--blue);
+  font-family: var(--mono);
+  font-size: 0.56rem;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.signal-line {
+  position: relative;
+  height: 40px;
+  margin-left: 24px;
+  border-left: 1px dashed #56617e;
+}
+
+.signal-line span {
+  position: absolute;
+  bottom: -3px;
+  left: -4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--mint);
+}
+
+.state-output {
+  display: flex;
+  min-height: 74px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px 18px;
+  border: 1px solid #3a4561;
+  background: #202941;
+}
+
+.state-output div {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.state-output span {
+  color: #909bb7;
+  font-family: var(--mono);
+  font-size: 0.57rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.state-output strong {
+  font-size: 0.88rem;
+}
+
+.state-output code {
+  padding: 7px 9px;
+  background: #12182a;
+  color: var(--mint);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+}
+
+.state-output code[data-tone='orange'] {
+  color: #ff9b84;
+}
+
+.state-output code[data-tone='violet'] {
+  color: #c6b4fa;
+}
+
+.key-strip {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 10px 18px;
+  border-top: 1px solid #303950;
+  color: #7f8aa5;
+  font-size: 0.58rem;
+  text-transform: uppercase;
+}
+
+.key-strip span:not(:first-child) {
+  margin-left: 8px;
+}
+
+kbd {
+  min-width: 25px;
+  padding: 4px 7px;
+  border: 1px solid #4a5571;
+  border-bottom-width: 2px;
+  background: #242d45;
+  color: white;
+  font-family: var(--mono);
+  font-size: 0.58rem;
+  text-align: center;
+}
+
+.features-section {
+  padding: clamp(76px, 10vw, 132px) clamp(24px, 5vw, 76px);
+  border-bottom: 1px solid var(--line);
+}
+
+.section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 52px;
+}
+
+.section-heading h2,
+.code-copy h2 {
+  margin: 12px 0 0;
+  font-size: clamp(2.2rem, 4.5vw, 4.8rem);
+  font-weight: 800;
+  letter-spacing: -0.065em;
+  line-height: 0.98;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.feature-card {
+  position: relative;
+  min-height: 280px;
+  padding: 36px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+
+.feature-card:nth-child(2) {
+  background: #eef2ff;
+}
+
+.feature-marker {
+  display: inline-grid;
+  min-width: 42px;
+  height: 42px;
+  padding: 0 8px;
+  border: 1px solid var(--ink);
+  background: var(--white);
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  font-weight: 500;
+  place-items: center;
+  box-shadow: 3px 3px 0 var(--orange);
+}
+
+.feature-card h3 {
+  margin: 56px 0 14px;
+  font-size: 1.08rem;
+  letter-spacing: -0.025em;
+}
+
+.feature-card p {
+  max-width: 320px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.7;
+}
+
+.code-section {
+  display: grid;
+  grid-template-columns: 0.78fr 1.22fr;
+  gap: clamp(50px, 8vw, 120px);
+  padding: clamp(76px, 10vw, 132px) clamp(24px, 5vw, 76px);
+  background: #e4e9f6;
+}
+
+.code-copy {
+  align-self: center;
+}
+
+.code-copy p:not(.section-kicker) {
+  margin: 28px 0 30px;
+  color: var(--muted);
+  font-size: 0.95rem;
+  line-height: 1.75;
+}
+
+.code-window {
+  min-width: 0;
+  border: 1px solid #252d43;
+  background: #11172b;
+  color: #e9edfa;
+  box-shadow: 12px 12px 0 var(--blue);
+}
+
+.code-toolbar {
+  display: grid;
+  min-height: 52px;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 0 20px;
+  border-bottom: 1px solid #303950;
+  color: #929db7;
+  font-family: var(--mono);
+  font-size: 0.6rem;
+}
+
+.code-toolbar > div {
+  display: flex;
+  gap: 6px;
+}
+
+.code-toolbar i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #536078;
+}
+
+.code-toolbar i:first-child {
+  background: var(--orange);
+}
+
+.code-toolbar i:nth-child(2) {
+  background: #f5cb66;
+}
+
+.code-toolbar i:nth-child(3) {
+  background: var(--mint);
+}
+
+.code-toolbar > span:last-child {
+  justify-self: end;
+}
+
+.code-window pre {
+  min-height: 390px;
+  padding: clamp(28px, 5vw, 56px);
+  margin: 0;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: clamp(0.72rem, 1.1vw, 0.9rem);
+  line-height: 1.9;
+  tab-size: 2;
+}
+
+.code-blue {
+  color: #8aa2ff;
+}
+
+.code-green {
+  color: var(--mint);
+}
+
+.code-violet {
+  color: #c8b8ff;
+}
+
+footer {
+  display: flex;
+  min-height: 150px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 34px clamp(24px, 5vw, 76px);
+  border-top: 1px solid var(--line);
+  background: var(--paper);
+}
+
+footer > div {
+  display: flex;
+  align-items: center;
+}
+
+footer p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.74rem;
+  line-height: 1.55;
+}
+
+@media (max-width: 1020px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-copy {
+    padding-bottom: 64px;
+  }
+
+  .control-lab {
+    margin: 0 clamp(24px, 5vw, 76px) 76px;
+  }
+
+  .feature-card {
+    padding: 28px;
+  }
+
+  .code-section {
+    grid-template-columns: 1fr;
+  }
+
+  .code-copy {
+    max-width: 640px;
+  }
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    min-height: 68px;
+  }
+
+  nav > a:not(.github-link) {
+    display: none;
+  }
+
+  .github-link span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  h1 {
+    font-size: clamp(3.2rem, 15vw, 5.2rem);
+  }
+
+  .install-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .install-command {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .install-command code {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .control-lab {
+    margin-right: 18px;
+    margin-left: 18px;
+    box-shadow: 7px 7px 0 #c8d2ee;
+  }
+
+  .lab-stage {
+    min-height: 360px;
+    padding: 40px 22px;
+  }
+
+  .key-strip {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-card {
+    min-height: 240px;
+  }
+
+  .feature-card h3 {
+    margin-top: 38px;
+  }
+
+  .code-window {
+    box-shadow: 7px 7px 0 var(--blue);
+  }
+
+  .code-window pre {
+    min-height: 340px;
+  }
+
+  footer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 28px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "scripts": {
     "build": "vite build --config vite.lib.config.ts && tsc -p tsconfig.build.json",
+    "build:demo": "vite build --config vite.demo.config.ts",
     "dev": "vite example",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,12 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true
   },
-  "include": ["src", "test", "example", "vite.lib.config.ts", "vitest.config.ts"]
+  "include": [
+    "src",
+    "test",
+    "example",
+    "vite.lib.config.ts",
+    "vite.demo.config.ts",
+    "vitest.config.ts"
+  ]
 }

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  root: 'example',
+  base: '/react-dropdown/',
+  build: {
+    outDir: '../demo-dist',
+    emptyOutDir: true,
+  },
+})


### PR DESCRIPTION
## Summary

- rebuild the GitHub Pages demo as a responsive product page
- make the accessible dropdown interaction the visual centerpiece
- add a dedicated Vite demo build and GitHub Pages deployment workflow

## Why

The published page still reflected the original legacy demo even though the package itself has been modernized for React 18 and 19. This brings the public demo in line with the current package, API, and accessibility story.

## Impact

Visitors get a mobile-friendly interactive demo, clearer installation guidance, feature documentation, and a direct path to the full API. Merging to `master` also deploys `demo-dist` through GitHub Actions.

## Validation

- `npm run check`
- `npm run build:demo`
- desktop and 390px responsive visual review
- pointer selection and selected-state verification
- no browser console errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the example app, build tooling, and CI; the published library package and runtime API are untouched.
> 
> **Overview**
> Replaces the minimal example page with a **full marketing-style demo** (hero, install copy-to-clipboard, feature grid, code sample, footer) and centers an interactive **Dropdown** showcase with grouped options, custom `renderOption`, and live selected-state output.
> 
> Adds **`vite.demo.config.ts`** (`base: /react-dropdown/`, output `demo-dist`), **`npm run build:demo`**, ignores `demo-dist`, and a **GitHub Actions** workflow that builds and deploys to GitHub Pages on `master` push (or manual dispatch).
> 
> Updates **`example/index.html`** with SEO/OG meta and refreshes **`example/src/style.css`** for responsive layout and demo-specific dropdown styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b866dac5fcff12f98481ce6655afcf88d33a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->